### PR TITLE
fix: load mass mailing css via manifest assets

### DIFF
--- a/whatsapp_connector_mass/__manifest__.py
+++ b/whatsapp_connector_mass/__manifest__.py
@@ -17,7 +17,7 @@
                'apichat.io Gupshup Chat-Api. ChatApi. Marketing whatsapp group ChatRoom 2.0.',
     'description': 'Send mass WhatsApp with Templates message Marketing. '
                    'apichat.io. Chat-Api. ChatApi. Marketing whatsapp group ChatRoom 2.0.',
-    'version': '14.0.20',
+    'version': '14.0.21',
     'author': 'AcruxLab',
     # 'live_test_url': 'https://chatroom.acruxlab.com/web/signup',
     'support': 'info@acruxlab.com',
@@ -41,7 +41,6 @@
         'data/cron.xml',
         'data/data.xml',
         'views/menus.xml',
-        'views/include_template.xml',
         'views/mailing_contact_views.xml',
         'views/mailing_list_views.xml',
         'views/mailing_mailing_views.xml',
@@ -53,6 +52,11 @@
         'wizards/mailing_sms_test_views.xml',
         'wizards/send_multi_views.xml',
     ],
+    'assets': {
+        'web.assets_backend': [
+            'whatsapp_connector_mass/static/src/css/mass_mailing.css',
+        ],
+    },
     'qweb': [
     ],
     'post_load': '',

--- a/whatsapp_connector_mass/views/include_template.xml
+++ b/whatsapp_connector_mass/views/include_template.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<odoo>
-    <template id="assets_backend" name="chatroom mass mailing assets" inherit_id="web.assets_backend">
-        <xpath expr="." position="inside">
-            <link rel="stylesheet" href="/whatsapp_connector_mass/static/src/css/mass_mailing.css" type="text/css"/>
-        </xpath>
-    </template>
-</odoo>


### PR DESCRIPTION
## Summary
- load whatsapp mass mailing stylesheet via module assets to avoid missing web.assets_backend reference
- remove obsolete XML asset template

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'odoo')*

------
https://chatgpt.com/codex/tasks/task_e_689f5e3407708324b96f14dca4e37cad