### PR TITLE
fix: replace scheduled field in mailing trace view

### DIFF
--- a/whatsapp_connector_mass/views/mailing_trace_views.xml
+++ b/whatsapp_connector_mass/views/mailing_trace_views.xml
@@ -9,7 +9,7 @@
                 <field name="mass_mailing_id"/>
                 <field name="ws_phone"/>
                 <field name="ws_message_id" />
-                <filter string="Scheduled" name="filter_scheduled" domain="[('scheduled', '!=', False), ('state', '=', 'outgoing')]"/>
+                <filter string="Scheduled" name="filter_scheduled" domain="[('schedule_date', '!=', False), ('state', '=', 'outgoing')]"/>
                 <filter string="Sent" name="filter_sent" domain="[('sent', '!=', False)]"/>
                 <filter string="Delivered" name="filter_delivered" domain="[('sent', '!=', False), ('state', 'not in', ['exception', 'bounced'])]"/>
                 <separator/>
@@ -69,7 +69,7 @@
                             <field name="res_id" groups="base.group_no_one"/>
                         </group>
                         <group>
-                            <field name="scheduled"/>
+                            <field name="schedule_date"/>
                             <field name="sent"/>
                             <field name="bounced"/>
                             <field name="exception"/>


### PR DESCRIPTION
## Summary
- fix unknown field in mailing trace view

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'odoo')*

------
https://chatgpt.com/codex/tasks/task_e_689f61d994f8832489b74ab77b4e9b98