### PR TITLE
Add schedule date related field to mailing traces

### DIFF
--- a/whatsapp_connector_mass/models/mailing_trace.py
+++ b/whatsapp_connector_mass/models/mailing_trace.py
@@ -16,6 +16,11 @@ class MailingTrace(models.Model):
     ws_error_msg_trace = fields.Char()
     ws_error_msg = fields.Char('Error', compute='_compute_ws_error_msg', store=True)
     ws_phone = fields.Char('Phone')
+    schedule_date = fields.Datetime(
+        related='mass_mailing_id.schedule_date',
+        string='Scheduled',
+        store=True,
+    )
 
     @api.depends('model', 'res_id')
     def _compute_ref_name(self):


### PR DESCRIPTION
## Summary
- expose mailing schedule date on mailing traces via related field

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'odoo')*
- `pip install odoo` *(fails: Could not find a version that satisfies the requirement odoo)*

------
https://chatgpt.com/codex/tasks/task_e_689f664c752c832483ea616bef64485a