### PR TITLE
Use mailing.trace state field

### DIFF
--- a/whatsapp_connector_mass/models/mailing_mailing.py
+++ b/whatsapp_connector_mass/models/mailing_mailing.py
@@ -182,6 +182,8 @@ class Mailing(models.Model):
                     'res_id': message.mailing_res_id,
                     'mass_mailing_id': mass.id,
                     'sent': fields.Datetime.now(),
+                    'trace_status': 'sent',
+                    'state': 'sent',
                     'ws_message_id': message.id,
                     'ws_phone': '+%s' % message.contact_id.number,
                 })
@@ -196,6 +198,8 @@ class Mailing(models.Model):
                     'res_id': record.id,
                     'mass_mailing_id': mass.id,
                     'exception': fields.Datetime.now(),
+                    'trace_status': 'exception',
+                    'state': 'exception',
                     'ws_error_msg_trace': msg,
                     'ws_phone': number,
                 })
@@ -761,9 +765,21 @@ class Mailing(models.Model):
                 else:
                     old_message.error_msg = str(e)
                     if trace_status == 'bounce':
-                        data = {'bounced': fields.Datetime.now(), 'exception': False, 'sent': False}
+                        data = {
+                            'bounced': fields.Datetime.now(),
+                            'exception': False,
+                            'sent': False,
+                            'trace_status': 'bounced',
+                            'state': 'bounced',
+                        }
                     else:
-                        data = {'exception': fields.Datetime.now(), 'bounced': False, 'sent': False}
+                        data = {
+                            'exception': fields.Datetime.now(),
+                            'bounced': False,
+                            'sent': False,
+                            'trace_status': 'exception',
+                            'state': 'exception',
+                        }
                     old_message.mailing_trace_ids.write(data)
             if sent_count == 0:
                 if self.loop_count < 3:

--- a/whatsapp_connector_mass/models/message.py
+++ b/whatsapp_connector_mass/models/message.py
@@ -20,9 +20,13 @@ class AcruxChatMessages(models.Model):
         '''
         out = super(AcruxChatMessages, self).message_send()
         if out:
-            self.mailing_trace_ids.write({'exception': False,
-                                          'bounced': False,
-                                          'sent': fields.Datetime.now()})
+            self.mailing_trace_ids.write({
+                'exception': False,
+                'bounced': False,
+                'sent': fields.Datetime.now(),
+                'trace_status': 'sent',
+                'state': 'sent',
+            })
         return out
 
     def process_message_event(self, data):


### PR DESCRIPTION
## Summary
- set mailing trace state after sending messages
- track state on trace creation and exception handling

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'odoo')*


------
https://chatgpt.com/codex/tasks/task_e_68a4ad83795c8324b0f9cadb0dd20f76