### PR TITLE
Use updated mailing trace datetime fields

### DIFF
--- a/whatsapp_connector_mass/models/mailing_mailing.py
+++ b/whatsapp_connector_mass/models/mailing_mailing.py
@@ -181,7 +181,7 @@ class Mailing(models.Model):
                     'model': mass.mailing_model_real,
                     'res_id': message.mailing_res_id,
                     'mass_mailing_id': mass.id,
-                    'sent': fields.Datetime.now(),
+                    'sent_datetime': fields.Datetime.now(),
                     'trace_status': 'sent',
                     'state': 'sent',
                     'ws_message_id': message.id,
@@ -197,7 +197,7 @@ class Mailing(models.Model):
                     'model': record._name,
                     'res_id': record.id,
                     'mass_mailing_id': mass.id,
-                    'exception': fields.Datetime.now(),
+                    'failure_datetime': fields.Datetime.now(),
                     'trace_status': 'exception',
                     'state': 'exception',
                     'ws_error_msg_trace': msg,
@@ -767,16 +767,16 @@ class Mailing(models.Model):
                     if trace_status == 'bounce':
                         data = {
                             'bounced': fields.Datetime.now(),
-                            'exception': False,
-                            'sent': False,
+                            'failure_datetime': False,
+                            'sent_datetime': False,
                             'trace_status': 'bounced',
                             'state': 'bounced',
                         }
                     else:
                         data = {
-                            'exception': fields.Datetime.now(),
+                            'failure_datetime': fields.Datetime.now(),
                             'bounced': False,
-                            'sent': False,
+                            'sent_datetime': False,
                             'trace_status': 'exception',
                             'state': 'exception',
                         }


### PR DESCRIPTION
## Summary
- replace deprecated `sent` and `exception` fields with `sent_datetime` and `failure_datetime` in mailing traces
- adjust error handler to write new datetime fields

## Testing
- `python -m py_compile whatsapp_connector_mass/models/mailing_mailing.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'odoo')*

------
https://chatgpt.com/codex/tasks/task_e_68a4b410366c8324a4eb223f80187998