### PR TITLE
Sync message templates dropdown and add menu entry

### DIFF
--- a/whatsapp_connector_mass/models/mailing_mailing.py
+++ b/whatsapp_connector_mass/models/mailing_mailing.py
@@ -51,9 +51,12 @@ class Mailing(models.Model):
     total_ws_sent = fields.Integer(compute='_compute_total_ws', store=False)
     total_ws_pend = fields.Integer(compute='_compute_total_ws', store=False)
     total_ws_contact = fields.Integer(compute='_compute_total_ws', store=False)
-    ws_template_id = fields.Many2one('mail.template', 'Template',
-                                     ondelete='set null',
-                                     domain="[('model', '=', mailing_model_real), ('name', 'ilike', 'ChatRoom')]")
+    ws_template_id = fields.Many2one(
+        'mail.template',
+        'Template',
+        ondelete='set null',
+        domain="[('name', 'ilike', 'ChatRoom'), ('waba_template_id.connector_id', '=', connector_id)]"
+    )
     message_limit = fields.Integer('Messages limit', default=0,
                                    help='Maximum messages number allowed to send in one day.')
     enable_from_hour = fields.Float('Enable From', help='00:00 to 23:59', default=0.0, required=True)
@@ -141,6 +144,12 @@ class Mailing(models.Model):
     @api.onchange('mailing_model_real')
     def onchange_ws_mailing_model_real(self):
         self.ws_template_id = False
+
+    @api.onchange('connector_id')
+    def onchange_connector_id(self):
+        self.ws_template_id = False
+        if self.connector_id:
+            self.connector_id.update_template_waba()
 
     @api.onchange('ws_template_id')
     def onchange_ws_template_id(self):

--- a/whatsapp_connector_mass/views/menus.xml
+++ b/whatsapp_connector_mass/views/menus.xml
@@ -66,5 +66,18 @@
                 action="utm.action_view_utm_tag"
                 sequence="30"
                  />
-                
+
+            <record id="whatsapp_mass_template_action" model="ir.actions.act_window">
+                <field name="name">Message Templates</field>
+                <field name="res_model">mail.template</field>
+                <field name="view_mode">tree,form</field>
+                <field name="domain">[('name', 'ilike', 'ChatRoom')]</field>
+            </record>
+
+            <menuitem id="whatsapp_mass_template_menu"
+                name="Message Templates"
+                parent="whatsapp_mass_menu_configuration"
+                action="whatsapp_mass_template_action"
+                sequence="40"/>
+
 </odoo>

--- a/whatsapp_connector_mass/wizards/send_multi.py
+++ b/whatsapp_connector_mass/wizards/send_multi.py
@@ -14,9 +14,12 @@ class AcruxSendMultiWizard(models.TransientModel):
     body_whatsapp = fields.Text('Message')
     body_whatsapp_html = fields.Html('Html Message', sanitize=False)
     model = fields.Char('Related Document Model', required=True)
-    ws_template_id = fields.Many2one('mail.template', 'Template',
-                                     ondelete='set null',
-                                     domain="[('model', '=', model), ('name', 'ilike', 'ChatRoom')]")
+    ws_template_id = fields.Many2one(
+        'mail.template',
+        'Template',
+        ondelete='set null',
+        domain="[('name', 'ilike', 'ChatRoom'), ('waba_template_id.connector_id', '=', connector_id)]"
+    )
     mark_invoice_as_sent = fields.Boolean('Mark as sent')
     chatter_log = fields.Boolean('Log in chatter')
     put_in_queue = fields.Boolean('Put in queue', default=True)
@@ -60,6 +63,12 @@ class AcruxSendMultiWizard(models.TransientModel):
         else:
             self.body_whatsapp = False
             self.body_whatsapp_html = False
+
+    @api.onchange('connector_id')
+    def onchange_connector_id(self):
+        self.ws_template_id = False
+        if self.connector_id:
+            self.connector_id.update_template_waba()
 
     def send_action(self):
         res_ids = self.env.context.get('active_ids')


### PR DESCRIPTION
## Summary
- Refresh available message templates when changing connector or sending mass messages
- Filter template selections by connector for consistent data
- Add Configuration menu entry to manage Message Templates

## Testing
- `python -m py_compile whatsapp_connector_mass/wizards/send_multi.py whatsapp_connector_mass/models/mailing_mailing.py`
- `xmllint --noout whatsapp_connector_mass/views/menus.xml` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a5dd5d773c8324a127109b90cd0c38