### PR TITLE
feat: simplify template selection

### DIFF
--- a/whatsapp_connector_mass/models/mailing_mailing.py
+++ b/whatsapp_connector_mass/models/mailing_mailing.py
@@ -55,7 +55,7 @@ class Mailing(models.Model):
         'mail.template',
         'Template',
         ondelete='set null',
-        domain="[('name', 'ilike', 'ChatRoom'), ('waba_template_id.connector_id', '=', connector_id)]"
+        domain="['|', ('waba_template_id', '=', False), ('waba_template_id.connector_id', '=', connector_id)]"
     )
     message_limit = fields.Integer('Messages limit', default=0,
                                    help='Maximum messages number allowed to send in one day.')

--- a/whatsapp_connector_mass/views/mailing_mailing_views.xml
+++ b/whatsapp_connector_mass/views/mailing_mailing_views.xml
@@ -248,7 +248,7 @@
                                     </div>
                                 </group>
                                 <group>
-                                    <field name="ws_template_id" options="{'no_create': True}"
+                                    <field name="ws_template_id"
                                            attrs="{'readonly': [('state', 'in', ('sending', 'done'))]}"/>
                                 </group>
                             </group>

--- a/whatsapp_connector_mass/views/menus.xml
+++ b/whatsapp_connector_mass/views/menus.xml
@@ -71,7 +71,6 @@
                 <field name="name">Message Templates</field>
                 <field name="res_model">mail.template</field>
                 <field name="view_mode">tree,form</field>
-                <field name="domain">[('name', 'ilike', 'ChatRoom')]</field>
             </record>
 
             <menuitem id="whatsapp_mass_template_menu"

--- a/whatsapp_connector_mass/wizards/send_multi.py
+++ b/whatsapp_connector_mass/wizards/send_multi.py
@@ -18,7 +18,7 @@ class AcruxSendMultiWizard(models.TransientModel):
         'mail.template',
         'Template',
         ondelete='set null',
-        domain="[('name', 'ilike', 'ChatRoom'), ('waba_template_id.connector_id', '=', connector_id)]"
+        domain="['|', ('waba_template_id', '=', False), ('waba_template_id.connector_id', '=', connector_id)]"
     )
     mark_invoice_as_sent = fields.Boolean('Mark as sent')
     chatter_log = fields.Boolean('Log in chatter')
@@ -52,7 +52,7 @@ class AcruxSendMultiWizard(models.TransientModel):
             res['name'] = '%s (%s)' % (self.env['ir.model']._get(model).name, date)
         if 'template_id' in default_fields and 'template_id' not in res:
             res['template_id'] = self.env['mail.template'].search(
-                [('model', '=', model), ('name', 'ilike', 'ChatRoom')], limit=1, order='name').id
+                [('model', '=', model)], limit=1, order='name').id
         return res
 
     @api.onchange('ws_template_id')

--- a/whatsapp_connector_mass/wizards/send_multi_views.xml
+++ b/whatsapp_connector_mass/wizards/send_multi_views.xml
@@ -17,7 +17,7 @@
                             <field name="connector_id"/>
                             <field name="put_in_queue"/>
                             <field name="check_unique_contact"/>
-                            <field name="ws_template_id" options="{'no_create': True}"/>
+                            <field name="ws_template_id"/>
                         </group>
                         <group colspan="2" col="1">
                             <label for="body_whatsapp"/>


### PR DESCRIPTION
## Summary
- allow choosing or creating any WhatsApp template linked to the connector
- remove ChatRoom-only filter from default template search and menu action
- enable template creation directly from mailing form and wizard

## Testing
- `python -m py_compile whatsapp_connector_mass/models/mailing_mailing.py whatsapp_connector_mass/wizards/send_multi.py`
- `python - <<'PY'
import xml.etree.ElementTree as ET
for f in ['whatsapp_connector_mass/views/mailing_mailing_views.xml', 'whatsapp_connector_mass/wizards/send_multi_views.xml', 'whatsapp_connector_mass/views/menus.xml']:
    ET.parse(f)
print('XML OK')
PY`
- `xmllint --noout whatsapp_connector_mass/views/mailing_mailing_views.xml whatsapp_connector_mass/wizards/send_multi_views.xml whatsapp_connector_mass/views/menus.xml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7263ee8708324b189acd40290ab8d