### PR TITLE
Use POST for template retrieval

### DIFF
--- a/whatsapp_connector/models/Connector.py
+++ b/whatsapp_connector/models/Connector.py
@@ -444,7 +444,7 @@ class AcruxChatConnector(models.Model):
             'contact_get_all': 'get',
             'init_free_test': 'post',
             'whatsapp_number_get': 'get',
-            'template_get': 'get',
+            'template_get': 'post',
             'opt_in': 'post',
         }
 


### PR DESCRIPTION
## Summary
- Fix template retrieval by switching `template_get` to POST

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a72cddf2b88324b508db72499a4d3d