### PR TITLE
Avoid extraneous stack trace in request error logging

### DIFF
--- a/whatsapp_connector/tools.py
+++ b/whatsapp_connector/tools.py
@@ -7,6 +7,7 @@ import requests
 import logging
 import mimetypes
 import re
+import sys
 from os.path import basename
 from datetime import date, datetime, timedelta
 import phonenumbers
@@ -14,6 +15,7 @@ from PIL import Image
 from odoo import fields, _, SUPERUSER_ID
 from odoo.exceptions import UserError
 from odoo.tools import image_process, image_to_base64, DEFAULT_SERVER_DATETIME_FORMAT
+
 _logger = logging.getLogger(__name__)
 
 TIMEOUT = (10, 20)
@@ -25,11 +27,15 @@ def log_request_error(param, req=None):
     try:
         param = json.dumps(param, indent=4, sort_keys=True, ensure_ascii=False)[:1000]
         if req is not None:
-            _logger.error('\nSTATUS: %s\nSEND: %s\nRESULT: %s' %
-                          (req.status_code, req.request.headers, req.text and req.text[:1000]))
+            _logger.error(
+                '\nSTATUS: %s\nSEND: %s\nRESULT: %s',
+                req.status_code,
+                req.request.headers,
+                req.text and req.text[:1000],
+            )
     except Exception:
         pass
-    _logger.error(param, exc_info=True)
+    _logger.error(param, exc_info=bool(sys.exc_info()[0]))
 
 
 def date2sure_str(value):


### PR DESCRIPTION
## Summary
- prevent `log_request_error` from printing a `NoneType` stack trace when no exception exists

## Testing
- `python -m py_compile whatsapp_connector/tools.py whatsapp_connector/models/Connector.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68ac68c3176883248f8702d978710a58